### PR TITLE
Add filter to vote on only unwatched movies

### DIFF
--- a/.byebug_history
+++ b/.byebug_history
@@ -1,4 +1,43 @@
 continue
+@session
+continue
+@session
+session_params
+continue
+movie['viewCount'].to_i == 0
+movie['viewCount'].to_i
+movie = movie.first
+movie =  movies.select { |movie| movie["title"].downcase.include?("65".downcase) }
+movie['viewCount'].to_i > 0
+movie['viewCount'].to_i
+movie['viewCount']
+movie = movie.first
+movie['viewCount']
+movie["viewCount"]
+movie =  movies.select { |movie| movie["title"].downcase.include?("suicide squad".downcase) }
+ movies.select { |movie| movie["title"].downcase.include?("suicide squad".downcase) }
+movies("title" => "#Alive")
+movies.first
+movies.find_by(title: "Suicide Squad")
+movies
+continue
+movies.first
+movies.pluck(:unwatched)
+movies.pluck(:watched)
+movies
+continue
+movies[544]
+movies[500]
+movies[50]
+movies[5]
+movies[4]
+movies.first
+continue
+movies.unwatched.pluck(:watched)
+movies.unwatched
+movies.all
+movies.first
+continue
 duration[:hours]
 duration = ActiveSupport::Duration.build(movie['duration'] / 1000).parts
 ActiveSupport::Duration.build(movie['duration'] / 1000).parts
@@ -215,34 +254,3 @@ response.body
     req.headers['X-Plex-Client-Identifier'] = user.plex_client_id
   end
 user
-response.body
- response = connection.get('/api/v2/resources') do |req|
-    req.headers['Accept'] = 'application/json'  # Request JSON to make parsing easier
-    req.headers['X-Plex-Token'] = user.plex_token
-  end
-continue
-response.body
- response = connection.get('/api/v2/resources') do |req|
-    req.headers['Accept'] = 'application/json'  # Request JSON to make parsing easier
-    req.headers['X-Plex-Token'] = user.plex_token
-  end
- response = connection.get("/library/sections") do |req|
-      req.headers['Accept'] = 'application/xml'
-      req.headers['X-Plex-Token'] = user.plex_token
-    end
- response = connection.get("/api/v2/library/sections") do |req|
-      req.headers['Accept'] = 'application/xml'
-      req.headers['X-Plex-Token'] = user.plex_token
-    end
-response = connection.get("/api/v2/library/sections") do |req|
-   49:       req.headers['Accept'] = 'application/xml'
-   50:       req.headers['X-Plex-Token'] = user.plex_token
-   51:     end
-connection
-continue
-response.body
-response = connection.get("/library/sections") do |req|
-      req.headers['Accept'] = 'application/xml'
-      req.headers['X-Plex-Token'] = user.plex_token
-    end
-response.body

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,8 +7,9 @@ class SessionsController < ApplicationController
 
   def create
     @session = current_user.sessions.new(session_params)
-    byebug
+    # Only show unwatched based on session.only_watched
     @movies = @session.only_unwatched ? current_user.movies.unwatched : current_user.movies
+    
     if @session.save
       # Create a voter for the main user
       @session.voters.create!(name: current_user.name, user: @session.user, session_owner: true)

--- a/app/controllers/sessions_controller.rb
+++ b/app/controllers/sessions_controller.rb
@@ -7,11 +7,13 @@ class SessionsController < ApplicationController
 
   def create
     @session = current_user.sessions.new(session_params)
+    byebug
+    @movies = @session.only_unwatched ? current_user.movies.unwatched : current_user.movies
     if @session.save
       # Create a voter for the main user
       @session.voters.create!(name: current_user.name, user: @session.user, session_owner: true)
 
-      selected_movies = current_user.movies.sample(5)
+      selected_movies = @movies.sample(5)
       @session.movies << selected_movies
 
       redirect_to @session, notice: 'Session created successfully!'
@@ -88,7 +90,7 @@ class SessionsController < ApplicationController
   private
 
   def session_params
-    params.require(:session).permit(:session_name)
+    params.require(:session).permit(:session_name, :only_unwatched)
   end
 
   def require_login

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -64,6 +64,7 @@ class VotesController < ApplicationController
   end
 
   def add_new_movies_to_session(movies)
+    movies = movies.unwatched if @session.only_unwatched
     # Add 5 new random movies
     new_movies = movies.sample(5)
     @session.movies << new_movies

--- a/app/controllers/votes_controller.rb
+++ b/app/controllers/votes_controller.rb
@@ -64,7 +64,9 @@ class VotesController < ApplicationController
   end
 
   def add_new_movies_to_session(movies)
+    # Only show unwatched based on session.only_watched
     movies = movies.unwatched if @session.only_unwatched
+
     # Add 5 new random movies
     new_movies = movies.sample(5)
     @session.movies << new_movies

--- a/app/jobs/fetch_and_store_movies_job.rb
+++ b/app/jobs/fetch_and_store_movies_job.rb
@@ -146,6 +146,7 @@ class FetchAndStoreMoviesJob < ApplicationJob
 
       if response.status == 200
         movies = JSON.parse(response.body)['MediaContainer']['Metadata']
+        
         Rails.logger.info("Found #{movies.length} movies in library #{library[:title]}")
         movies.each do |movie|
           create_or_update_movie(user, movie, library)
@@ -172,7 +173,8 @@ class FetchAndStoreMoviesJob < ApplicationJob
       summary: movie['summary'],
       content_rating: movie['contentRating'],
       audience_rating: movie['audienceRating'],
-      rating: movie['rating']
+      rating: movie['rating'],
+      unwatched: movie['viewCount'].to_i == 0
     )
     Rails.logger.info("Created or updated movie: #{movie['title']}")
   end

--- a/app/models/movie.rb
+++ b/app/models/movie.rb
@@ -2,4 +2,6 @@ class Movie < ApplicationRecord
   belongs_to :user
   has_and_belongs_to_many :sessions
   has_many :votes, dependent: :destroy
+
+  scope :unwatched, -> { where(unwatched: true) }
 end

--- a/app/views/sessions/_form.html.erb
+++ b/app/views/sessions/_form.html.erb
@@ -3,6 +3,10 @@
     <%= f.label :session_name, "Session Name", class: "label" %>
     <%= f.text_field :session_name, class: "input", placeholder: "Scary movie night with Chucky" %>
   </div>
-
+  <div class="field">
+    <label class="checkbox">
+      <%= f.check_box :only_unwatched %> Only include unwatched movies
+    </label>
+  </div>
   <%= f.submit "Create Session", class: "button is-primary" %>
 <% end %>

--- a/db/migrate/20240903014156_add_watched_to_movies.rb
+++ b/db/migrate/20240903014156_add_watched_to_movies.rb
@@ -1,0 +1,5 @@
+class AddWatchedToMovies < ActiveRecord::Migration[7.1]
+  def change
+    add_column :movies, :unwatched, :boolean, default: false
+  end
+end

--- a/db/migrate/20240903020048_add_only_watched_to_sessions.rb
+++ b/db/migrate/20240903020048_add_only_watched_to_sessions.rb
@@ -1,0 +1,5 @@
+class AddOnlyWatchedToSessions < ActiveRecord::Migration[7.1]
+  def change
+    add_column :sessions, :only_unwatched, :boolean, default: false
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema[7.1].define(version: 2024_09_02_054734) do
+ActiveRecord::Schema[7.1].define(version: 2024_09_03_020048) do
   # These are extensions that must be enabled in order to support this database
   enable_extension "plpgsql"
 
@@ -31,6 +31,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_054734) do
     t.bigint "user_id", null: false
     t.integer "year"
     t.integer "duration"
+    t.boolean "unwatched", default: false
     t.index ["user_id"], name: "index_movies_on_user_id"
   end
 
@@ -47,6 +48,7 @@ ActiveRecord::Schema[7.1].define(version: 2024_09_02_054734) do
     t.datetime "created_at", null: false
     t.datetime "updated_at", null: false
     t.string "session_name"
+    t.boolean "only_unwatched", default: false
     t.index ["user_id"], name: "index_sessions_on_user_id"
     t.index ["winner_type", "winner_id"], name: "index_sessions_on_winner"
   end


### PR DESCRIPTION
# Purpose
Add the ability to only vote on unwatched videos

# Method

Added reading the view count of the Plex movies to determine if the movie has been watched. 

```ruby
unwatched: movie['viewCount'].to_i == 0
``` 

A scope is added to the movie model for unwatched movies
```ruby
scope :unwatched, -> { where(unwatched: true) }
```

An `only_unwatched` boolean field was added to the Session object. When this is set to true by the checkbox in the form the movies added to the session are unwatched movies.
```ruby
@movies = @session.only_unwatched ? current_user.movies.unwatched : current_user.movies
```

The same logic is used in the votes controller when more movies are added to the session when the current batch of movies has been voted on
```ruby
  def add_new_movies_to_session(movies)
    # Only show unwatched based on session.only_watched
    movies = movies.unwatched if @session.only_unwatched

    # Add 5 new random movies
    new_movies = movies.sample(5)
    @session.movies << new_movies
  end
```

Now do you have to waste votes on movies you haven't seen if you don't want to.